### PR TITLE
Added a wait to not hit maven central too rapidly by default

### DIFF
--- a/upload.kts
+++ b/upload.kts
@@ -112,9 +112,12 @@ class MainCommand : CliktCommand() {
           fileCount = total
         }
         println("\r  $fileCount files uploaded to '$repositoryId'")
-
         println("\r  closing version $it...")
         client.closeRepositories(listOf(repositoryId))
+        client.waitForClose(repositoryId = repositoryId, pollingIntervalMillis = 20_000) {
+          println("Waiting for build to close...")
+          System.out.flush()
+        }
         ids.add(it to repositoryId)
       }
     }


### PR DESCRIPTION
Accounts can get temporarily suspended if builds are uploaded too rapidly. It happened to me after which I added added the wait line to my script and it's working fine ever since. 

Feels like it's better to make it the default way?