### PR TITLE
Fix capitalization and spelling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@ Vespene is a set of tools to help library maintainers upload existing packages t
 For now, the main focuses are:
 * Avoiding split repositories during upload by [creating a staging repository](https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API) before upload and uploading all files to this staging repository.
 * GPG Signing without having to deal with GPG using [BouncyCastle](https://www.bouncycastle.org/) instead.  
-* Helpers for md5/sha1 cheksums.
+* Helpers for md5/sha1 checksums.
 * A Nexus 2.x (OSSRH is still on 2.x) API that gathers scattered documentation. 
 * Automating (almost) everything
 
 More to come, contributions welcome!
 
-## Moving existing artifacts from jcenter to mavenCentral
+## Moving existing artifacts from JCenter to Maven Central
 
-With jcenter shutting down, moving existing artifacts to mavenCentral will make sure older versions will stay available in the long term. Bintray has a very handy [sync checkbox](https://www.jfrog.com/confluence/display/BT/Syncing+with+Third-Party+Platforms) that syncs artifacts to MavenCentral. This works well with two limitations:
+With JCenter shutting down, moving existing artifacts to Maven Central will make sure older versions will stay available in the long term. Bintray has a very handy [sync checkbox](https://www.jfrog.com/confluence/display/BT/Syncing+with+Third-Party+Platforms) that syncs artifacts to Maven Central. This works well with two limitations:
 
 * That gives your sonatype credentials to Bintray.
 * It doesn't work if your artifacts do not pass the [mavenCentral requirements](https://central.sonatype.org/pages/requirements.html)
 
-That last point can happen relatively frequently given that jcenter is less strict than mavenCentral and allows artifacts without sources/javadoc, pom files with missing information, etc..
+That last point can happen relatively frequently given that JCenter is less strict than Maven Central and allows artifacts without sources/javadoc, pom files with missing information, etc..
 
 Vespene comes with a [kscript-based](https://github.com/holgerbrandl/kscript) script to automate much of the process of re-computing checksums, signatures, etc..
 
@@ -30,7 +30,7 @@ To upload with the bundled [upload.kts](upload.kts) script:
 
 ```shell
 # Use lftp to download your existing files
-# Try not to download all of jcenter if possible 😅
+# Try not to download all of JCenter if possible 😅
 brew install lftp
 lftp https://jcenter.bintray.com/com/example/
 > mirror . my-local-repo
@@ -67,9 +67,9 @@ export GPG_PRIVATE_KEY_PASSWORD=...
 
 ## Using the lib
 
-The provided script makes some assumptions. It's going to reuse the existing jcenter signatures for an example to make as little changes as possible to the existing files but this might be inconvenient. 
+The provided script makes some assumptions. It's going to reuse the existing JCenter signatures for an example to make as little changes as possible to the existing files but this might be inconvenient. 
 
-If you want to tweak the script, or want to do other Nexus operations, You can also use the API directly from the `vespene-lib` artifact:
+If you want to tweak the script, or want to do other Nexus operations, you can also use the API directly from the `vespene-lib` artifact:
 
 ```
 dependencies {
@@ -91,7 +91,7 @@ And use NexusStagingClient:
   // release/drop/etc...
 ```
 
-Contributions/Questions welcome
+Contributions/questions are welcome.
 
 
 


### PR DESCRIPTION
- Fix a few spellings, typo.
- Use consistent capitalization for `JCenter` and `Maven Central`.